### PR TITLE
Fix: Allow more time for process termination

### DIFF
--- a/executable.go
+++ b/executable.go
@@ -234,8 +234,8 @@ func (e *Executable) Kill() error {
 	select {
 	case doneError := <-doneChannel:
 		err = doneError
-	case <-time.After(1 * time.Second):
-		err = fmt.Errorf("program failed to exit in 1 second after receiving sigterm")
+	case <-time.After(2 * time.Second):
+		err = fmt.Errorf("program failed to exit in 2 seconds after receiving sigterm")
 		syscall.Kill(e.cmd.Process.Pid, syscall.SIGKILL)  // Don't know if this is required
 		syscall.Kill(-e.cmd.Process.Pid, syscall.SIGKILL) // Kill the whole process group
 	}

--- a/executable_test.go
+++ b/executable_test.go
@@ -146,5 +146,5 @@ func TestTerminatesRoguePrograms(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	err = e.Kill()
-	assert.EqualError(t, err, "program failed to exit in 1 second after receiving sigterm")
+	assert.EqualError(t, err, "program failed to exit in 2 seconds after receiving sigterm")
 }


### PR DESCRIPTION
BEAM can take longer than one second to exit, which prevents the Elixir track tests from working correctly.

Before the wait time was increased:
![image](https://user-images.githubusercontent.com/6024227/212739616-3a9e883d-b9be-4f41-acfd-1a1717a3aaae.png)

After the wait time was increased:
![image](https://user-images.githubusercontent.com/6024227/212739655-2a23a7fd-954b-4118-9be3-fe964c4cbd7f.png)
