### PR TITLE
CC-1165: Fix exe#kill issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.history/


### PR DESCRIPTION
In case cmd.Start() failed, e.cmd was in mismatched state before we returned error. 

Then we relied on this wrong state info to check if exe was Running before attempting kill.

To fix this we only set e.cmd when we know it is safe to do so, and can rely on this info. 