### PR TITLE
CC-1181: Add secondary prefix to logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -53,6 +53,9 @@ type Logger struct {
 	// IsQuiet is used to determine whether to emit non-critical logs.
 	IsQuiet bool
 
+	// Prefix is the prefix to be used for all logs.
+	Prefix string
+
 	logger log.Logger
 }
 
@@ -60,10 +63,23 @@ type Logger struct {
 func GetLogger(isDebug bool, prefix string) *Logger {
 	color.NoColor = false
 
-	prefix = yellowColorize(prefix)[0]
+	coloredPrefix := yellowColorize(prefix)[0]
 	return &Logger{
-		logger:  *log.New(os.Stdout, prefix, 0),
+		logger:  *log.New(os.Stdout, coloredPrefix, 0),
 		IsDebug: isDebug,
+		Prefix:  prefix,
+	}
+}
+
+// GetLoggerWithAppendedPrefix Returns a logger after appending a prefix to the existing prefix.
+func (l *Logger) GetLoggerWithAppendedPrefix(prefix string) *Logger {
+	color.NoColor = false
+
+	coloredPrefix := yellowColorize(l.Prefix + fmt.Sprintf("[%s] ", prefix))[0]
+	return &Logger{
+		logger:  *log.New(os.Stdout, coloredPrefix, 0),
+		IsDebug: l.IsDebug,
+		Prefix:  prefix,
 	}
 }
 
@@ -71,11 +87,12 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 func GetQuietLogger(prefix string) *Logger {
 	color.NoColor = false
 
-	prefix = yellowColorize(prefix)[0]
+	coloredPrefix := yellowColorize(prefix)[0]
 	return &Logger{
-		logger:  *log.New(os.Stdout, prefix, 0),
+		logger:  *log.New(os.Stdout, coloredPrefix, 0),
 		IsDebug: false,
 		IsQuiet: true,
+		Prefix:  prefix,
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -74,7 +74,7 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 	}
 }
 
-func (l *Logger) UpdateSecondaryPrefix(prefix string) error {
+func (l *Logger) UpdateSecondaryPrefix(prefix string) {
 	l.secondaryPrefix = prefix
 	if prefix == "" {
 		// Reset the prefix to the original one.
@@ -83,14 +83,10 @@ func (l *Logger) UpdateSecondaryPrefix(prefix string) error {
 		// Append the secondary prefix to the original one.
 		l.logger.SetPrefix(yellowColorize(l.prefix + fmt.Sprintf("[%s] ", prefix))[0])
 	}
-	return nil
 }
 
-func (l *Logger) ResetSecondaryPrefix() error {
-	if err := l.UpdateSecondaryPrefix(""); err != nil {
-		return err
-	}
-	return nil
+func (l *Logger) ResetSecondaryPrefix() {
+	l.UpdateSecondaryPrefix("")
 }
 
 // GetQuietLogger Returns a logger that only emits critical logs. Useful for anti-cheat stages.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -53,8 +53,11 @@ type Logger struct {
 	// IsQuiet is used to determine whether to emit non-critical logs.
 	IsQuiet bool
 
-	// Prefix is the prefix to be used for all logs.
-	Prefix string
+	// prefix is the prefix to be used for all logs.
+	prefix string
+
+	// SecondaryPrefix is a secondary prefix, that can be dynamically appended to the prefix.
+	SecondaryPrefix string
 
 	logger log.Logger
 }
@@ -67,20 +70,18 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 	return &Logger{
 		logger:  *log.New(os.Stdout, coloredPrefix, 0),
 		IsDebug: isDebug,
-		Prefix:  prefix,
+		prefix:  prefix,
 	}
 }
 
-// GetLoggerWithAppendedPrefix Returns a logger after appending a prefix to the existing prefix.
-func (l *Logger) GetLoggerWithAppendedPrefix(prefix string) *Logger {
-	color.NoColor = false
-
-	coloredPrefix := yellowColorize(l.Prefix + fmt.Sprintf("[%s] ", prefix))[0]
-	return &Logger{
-		logger:  *log.New(os.Stdout, coloredPrefix, 0),
-		IsDebug: l.IsDebug,
-		Prefix:  prefix,
+func (l *Logger) UpdateSecondaryPrefix(prefix string) error {
+	l.SecondaryPrefix = prefix
+	if prefix == "" {
+		l.logger.SetPrefix(yellowColorize(l.prefix)[0])
+	} else {
+		l.logger.SetPrefix(yellowColorize(l.prefix + fmt.Sprintf("[%s] ", prefix))[0])
 	}
+	return nil
 }
 
 // GetQuietLogger Returns a logger that only emits critical logs. Useful for anti-cheat stages.
@@ -92,7 +93,7 @@ func GetQuietLogger(prefix string) *Logger {
 		logger:  *log.New(os.Stdout, coloredPrefix, 0),
 		IsDebug: false,
 		IsQuiet: true,
-		Prefix:  prefix,
+		prefix:  prefix,
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -56,8 +56,8 @@ type Logger struct {
 	// prefix is the prefix to be used for all logs.
 	prefix string
 
-	// SecondaryPrefix is a secondary prefix, that can be dynamically appended to the prefix.
-	SecondaryPrefix string
+	// secondaryPrefix is a secondary prefix, that can be dynamically appended to the prefix.
+	secondaryPrefix string
 
 	logger log.Logger
 }
@@ -75,11 +75,20 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 }
 
 func (l *Logger) UpdateSecondaryPrefix(prefix string) error {
-	l.SecondaryPrefix = prefix
+	l.secondaryPrefix = prefix
 	if prefix == "" {
+		// Reset the prefix to the original one.
 		l.logger.SetPrefix(yellowColorize(l.prefix)[0])
 	} else {
+		// Append the secondary prefix to the original one.
 		l.logger.SetPrefix(yellowColorize(l.prefix + fmt.Sprintf("[%s] ", prefix))[0])
+	}
+	return nil
+}
+
+func (l *Logger) ResetSecondaryPrefix() error {
+	if err := l.UpdateSecondaryPrefix(""); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the logging functionality in the `logger/logger.go` file. The key changes include the addition of two new fields in the `Logger` struct, namely `prefix` and `secondaryPrefix`. These new fields allow for more dynamic log prefixing. Additionally, two new methods have been introduced, `UpdateSecondaryPrefix` and `ResetSecondaryPrefix`, to manage the secondary prefix.

Here are the key changes:

* [`logger/logger.go`](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348R56-R105): Added two new fields, `prefix` and `secondaryPrefix`, to the `Logger` struct. These fields are used to manage the prefixes for the logs.
* [`logger/logger.go`](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348R56-R105): Modified the `GetLogger` and `GetQuietLogger` functions to initialize the new `prefix` field.
* [`logger/logger.go`](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348R56-R105): Introduced a new method `UpdateSecondaryPrefix` that allows updating the secondary prefix and appending it to the primary prefix. If an empty string is passed, it resets the prefix to the original one.
* [`logger/logger.go`](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348R56-R105): Added a new method `ResetSecondaryPrefix` that resets the secondary prefix to an empty string.This pull request adds a new method, `GetLoggerWithAppendedPrefix`, which allows appending a secondary prefix to the existing logger prefix. Additionally, the existing `UpdateSecondaryPrefix` method has been refactored to dynamically update the secondary prefix, and a new `ResetSecondaryPrefix` method has been added to reset the secondary prefix to its original value. These changes enhance the flexibility and functionality of the logger.