### PR TITLE
Add GetSecondaryPrefix method

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -75,14 +75,20 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 }
 
 func (l *Logger) UpdateSecondaryPrefix(prefix string) {
+	// Pass in the actual prefix that will be used.
+	// Else, if we want to use a series of [prefix1][prefix2] that fails
 	l.secondaryPrefix = prefix
 	if prefix == "" {
 		// Reset the prefix to the original one.
 		l.logger.SetPrefix(yellowColorize(l.prefix)[0])
 	} else {
 		// Append the secondary prefix to the original one.
-		l.logger.SetPrefix(yellowColorize(l.prefix + fmt.Sprintf("[%s] ", prefix))[0])
+		l.logger.SetPrefix(yellowColorize(l.prefix + prefix)[0])
 	}
+}
+
+func (l *Logger) GetSecondaryPrefix() string {
+	return l.secondaryPrefix
 }
 
 func (l *Logger) ResetSecondaryPrefix() {


### PR DESCRIPTION
This pull request adds the GetSecondaryPrefix method in order to improve maintainability. The method now returns the secondary prefix used by the logger. Additionally, the UpdateSecondaryPrefix method has been modified to correctly handle the case when a series of prefixes is used.