### PR TITLE
Part of CC-1381: Add anti-cheat test case for grep

### DIFF
--- a/executable/executable_test.go
+++ b/executable/executable_test.go
@@ -174,6 +174,21 @@ func TestRunWithStdin(t *testing.T) {
 	assert.Equal(t, result.ExitCode, 1)
 }
 
+func TestRunWithStdinTimeout(t *testing.T) {
+	e := NewExecutable("sleep")
+	e.TimeoutInSecs = 2
+
+	result, err := e.RunWithStdin([]byte(""), "10")
+	assert.NoError(t, err)
+	assert.Equal(t, result.Timeout, true)
+	assert.Equal(t, result.ExitCode, -1)
+
+	result, err = e.RunWithStdin([]byte(""), "1")
+	assert.NoError(t, err)
+	assert.Equal(t, result.Timeout, false)
+	assert.Equal(t, result.ExitCode, 0)
+}
+
 // Rogue == doesn't respond to SIGTERM
 func TestTerminatesRoguePrograms(t *testing.T) {
 	e := NewExecutable("bash")

--- a/executable/executable_test.go
+++ b/executable/executable_test.go
@@ -176,16 +176,14 @@ func TestRunWithStdin(t *testing.T) {
 
 func TestRunWithStdinTimeout(t *testing.T) {
 	e := NewExecutable("sleep")
-	e.TimeoutInSecs = 2
+	e.TimeoutInMilliseconds = 50
 
 	result, err := e.RunWithStdin([]byte(""), "10")
-	assert.NoError(t, err)
-	assert.Equal(t, result.Timeout, true)
-	assert.Equal(t, result.ExitCode, -1)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "execution timed out")
 
-	result, err = e.RunWithStdin([]byte(""), "1")
+	result, err = e.RunWithStdin([]byte(""), "0.02")
 	assert.NoError(t, err)
-	assert.Equal(t, result.Timeout, false)
 	assert.Equal(t, result.ExitCode, 0)
 }
 


### PR DESCRIPTION
- Need `executable.RunWithStdin` to support **timeout** for innocent user code hanging on anti-cheat test cases.

- Note: executables were initialized with a `timeoutInSecs` of **10 seconds**, which means nothing before this PR, **but will be effective** thereafter. 

  - Not sure the 10 seconds are or aren't long enough for other code depending on `New[Verbose]Executable`, but just want to call attention to the potential repercussion.

https://github.com/codecrafters-io/tester-utils/blob/df66fbcb98e57db04883fc93830a97b24e37e3f6/executable/executable.go#L78-L86

- [x] Added test: `TestRunWithStdinTimeout`

```bash
❯ go test -v ./executable/...

=== RUN   TestStart
--- PASS: TestStart (0.00s)
=== RUN   TestStartAndKill
--- PASS: TestStartAndKill (0.00s)
=== RUN   TestRun
--- PASS: TestRun (0.00s)
=== RUN   TestOutputCapture
--- PASS: TestOutputCapture (0.01s)
=== RUN   TestLargeOutputCapture
--- PASS: TestLargeOutputCapture (0.71s)
=== RUN   TestExitCode
--- PASS: TestExitCode (0.01s)
=== RUN   TestExecutableStartNotAllowedIfInProgress
--- PASS: TestExecutableStartNotAllowedIfInProgress (0.01s)
=== RUN   TestSuccessiveExecutions
--- PASS: TestSuccessiveExecutions (0.00s)
=== RUN   TestHasExited
--- PASS: TestHasExited (0.15s)
=== RUN   TestStdin
--- PASS: TestStdin (0.10s)
=== RUN   TestRunWithStdin
--- PASS: TestRunWithStdin (0.00s)
=== RUN   TestRunWithStdinTimeout
--- PASS: TestRunWithStdinTimeout (3.01s)
=== RUN   TestTerminatesRoguePrograms
--- PASS: TestTerminatesRoguePrograms (4.22s)
PASS
ok  	github.com/codecrafters-io/tester-utils/executable	8.701s
```