### PR TITLE
CC-1414: Handle codecrafters.yml errors better, and don't mark as internal error

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,9 +1,9 @@
 package internal
 
-type FriendlyError struct {
-	UserError string
+type UserError struct {
+	Message string
 }
 
-func (e *FriendlyError) Error() string {
-	return e.UserError
+func (e *UserError) Error() string {
+	return e.Message
 }

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,9 @@
+package internal
+
+type FriendlyError struct {
+	UserError string
+}
+
+func (e *FriendlyError) Error() string {
+	return e.UserError
+}

--- a/tester.go
+++ b/tester.go
@@ -21,12 +21,10 @@ type Tester struct {
 func newTester(env map[string]string, definition tester_definition.TesterDefinition) (Tester, error) {
 	context, err := tester_context.GetTesterContext(env, definition)
 	if err != nil {
-		if friendlyErr, ok := err.(*internal.FriendlyError); ok {
-			fmt.Printf(friendlyErr.UserError)
-			return Tester{}, fmt.Errorf(friendlyErr.UserError)
+		if userError, ok := err.(*internal.UserError); ok {
+			return Tester{}, fmt.Errorf(userError.Message)
 		}
 
-		fmt.Printf("CodeCrafters internal error. Error fetching tester context: %v", err)
 		return Tester{}, fmt.Errorf("CodeCrafters internal error. Error fetching tester context: %v", err)
 	}
 
@@ -48,7 +46,7 @@ func RunCLI(env map[string]string, definition tester_definition.TesterDefinition
 
 	tester, err := newTester(env, definition)
 	if err != nil {
-		fmt.Printf("%s", err)
+		fmt.Println(err.Error())
 		return 1
 	}
 

--- a/tester.go
+++ b/tester.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/codecrafters-io/tester-utils/executable"
+	"github.com/codecrafters-io/tester-utils/internal"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_runner"
@@ -20,6 +21,11 @@ type Tester struct {
 func newTester(env map[string]string, definition tester_definition.TesterDefinition) (Tester, error) {
 	context, err := tester_context.GetTesterContext(env, definition)
 	if err != nil {
+		if friendlyErr, ok := err.(*internal.FriendlyError); ok {
+			fmt.Printf(friendlyErr.UserError)
+			return Tester{}, fmt.Errorf(friendlyErr.UserError)
+		}
+
 		fmt.Printf("CodeCrafters internal error. Error fetching tester context: %v", err)
 		return Tester{}, fmt.Errorf("CodeCrafters internal error. Error fetching tester context: %v", err)
 	}

--- a/tester_context/tester_context.go
+++ b/tester_context/tester_context.go
@@ -117,14 +117,14 @@ func readFromYAML(configPath string) (yamlConfig, error) {
 
 	fileContents, err := os.ReadFile(configPath)
 	if err != nil {
-		return yamlConfig{}, &internal.FriendlyError{
-			UserError: "Can't read codecrafters.yml file in your repository. This is required to run tests.",
+		return yamlConfig{}, &internal.UserError{
+			Message: "Can't read codecrafters.yml file in your repository. This is required to run tests.",
 		}
 	}
 
 	if err := yaml.Unmarshal(fileContents, c); err != nil {
-		return yamlConfig{}, &internal.FriendlyError{
-			UserError: fmt.Sprintf("Error parsing codecrafters.yml: %s", err),
+		return yamlConfig{}, &internal.UserError{
+			Message: fmt.Sprintf("Error parsing codecrafters.yml: %s", err),
 		}
 	}
 

--- a/tester_context/tester_context.go
+++ b/tester_context/tester_context.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
+	"github.com/codecrafters-io/tester-utils/internal"
 	"github.com/codecrafters-io/tester-utils/tester_definition"
 	"gopkg.in/yaml.v2"
 )
@@ -115,13 +115,17 @@ func GetTesterContext(env map[string]string, definition tester_definition.Tester
 func readFromYAML(configPath string) (yamlConfig, error) {
 	c := &yamlConfig{}
 
-	fileContents, err := ioutil.ReadFile(configPath)
+	fileContents, err := os.ReadFile(configPath)
 	if err != nil {
-		return yamlConfig{}, err
+		return yamlConfig{}, &internal.FriendlyError{
+			UserError: "Can't read codecrafters.yml file in your repository. This is required to run tests.",
+		}
 	}
 
 	if err := yaml.Unmarshal(fileContents, c); err != nil {
-		return yamlConfig{}, err
+		return yamlConfig{}, &internal.FriendlyError{
+			UserError: fmt.Sprintf("Error parsing codecrafters.yml: %s", err),
+		}
 	}
 
 	return *c, nil


### PR DESCRIPTION
This PR introduces user-friendly error handling by implementing `FriendlyError`. 

1. Added FriendlyError struct.
2. Implemented FriendlyError handling in `readFromYAML` function, providing users with a clearer message when the codecrafters.yml file is missing or malformed
3. Updated error handling logic to display the FriendlyError message, instead of an internal error.