### PR TITLE
Add GetSecondaryPrefix method to logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -74,6 +74,10 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 	}
 }
 
+func (l *Logger) GetSecondaryPrefix() string {
+	return l.secondaryPrefix
+}
+
 func (l *Logger) UpdateSecondaryPrefix(prefix string) {
 	l.secondaryPrefix = prefix
 	if prefix == "" {


### PR DESCRIPTION
Introduce a method to retrieve the secondary prefix from the logger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled retrieval of an additional logging attribute to enhance log detail without altering existing log update functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->