### PR TITLE
Refactor logger and clean up workflow file

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -7,7 +7,7 @@
 name: Trigger Fixture Regeneration
 
 on:
-  workflow_call:  
+  workflow_call:
     inputs:
       tester_repo:
         description: "The repo to regenerate fixtures for"
@@ -39,7 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: regenerate-fixtures
-          
+
       - name: Set up prerequisites (interpreter)
         if: inputs.tester_repo == 'interpreter-tester'
         uses: codecrafters-io/codecrafters-action/.github/actions/interpreter-setup@b7d515cea86f1815ce74c6eeb0cb15fb458eda88
@@ -57,7 +57,7 @@ jobs:
           git checkout ${{ github.head_ref }}
 
       - name: Regenerate Fixtures
-        run: CODECRAFTERS_RECORD_FIXTURES=true make test 
+        run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures
         run: |

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -217,13 +217,13 @@ func (l *Logger) Debugln(msg string) {
 func (l *Logger) Plainf(fstring string, args ...any) {
 	formattedString := fmt.Sprintf(fstring, args...)
 
-	for line := range strings.Split(formattedString, "\n") {
+	for line := range strings.SplitSeq(formattedString, "\n") {
 		l.logger.Println(line)
 	}
 }
 
 func (l *Logger) Plainln(msg string) {
-	lines := strings.Split(msg, "\n")
+	lines := strings.SplitSeq(msg, "\n")
 
 	for line := range lines {
 		l.logger.Println(line)


### PR DESCRIPTION
Update the logger to use `strings.SplitSeq` for better line splitting and remove unnecessary whitespace in the GitHub Actions workflow file.