### PR TITLE
Update: Logger structure

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -82,25 +82,25 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 }
 
 // GetSecondaryPrefix returns the first secondary prefix
-func (l *Logger) GetSecondaryPrefix() string {
-	if len(l.secondaryPrefixes) == 0 {
-		return ""
-	}
-	return l.secondaryPrefixes[0]
+func (l *Logger) GetSecondaryPrefixes() []string {
+	return l.secondaryPrefixes
 }
 
-// UpdateSecondaryPrefix replaces all secondary prefixes with the new one
-// for backward compatibility
-func (l *Logger) UpdateSecondaryPrefix(prefix string) {
-	l.secondaryPrefixes = []string{}
-	if prefix != "" {
-		l.secondaryPrefixes = append(l.secondaryPrefixes, prefix)
-	}
+// UpdateSecondaryPrefixes replaces all secondary prefixes with the new one
+func (l *Logger) UpdateSecondaryPrefixes(prefixes []string) {
+	l.secondaryPrefixes = prefixes
 	l.updateLoggerPrefix()
 }
 
-// ResetSecondaryPrefix clears all secondary prefixes
-func (l *Logger) ResetSecondaryPrefix() {
+// UpdateLastSecondaryPrefix updates the secondary prefix at the top of SecondaryPrefixes stack
+func (l *Logger) UpdateLastSecondaryPrefix(newPrefix string) {
+	l.PopSecondaryPrefix()
+	l.PushSecondaryPrefix(newPrefix)
+	l.updateLoggerPrefix()
+}
+
+// ResetSecondaryPrefixes clears all secondary prefixes
+func (l *Logger) ResetSecondaryPrefixes() {
 	// Backward compatibility: clear all secondary prefixes
 	l.secondaryPrefixes = []string{}
 	l.updateLoggerPrefix()
@@ -119,13 +119,13 @@ func (l *Logger) updateLoggerPrefix() {
 	}
 }
 
-// PushSecondaryPrefix adds a new secondary prefix to the end of secondaryPrefixes slice
+// PushSecondaryPrefix pushes a new secondary prefix to secondaryPrefixes
 func (l *Logger) PushSecondaryPrefix(prefix string) {
 	l.secondaryPrefixes = append(l.secondaryPrefixes, prefix)
 	l.updateLoggerPrefix()
 }
 
-// PopSecondaryPrefix removes the last secondary prefix from the secondaryPrefixes slice
+// PopSecondaryPrefix removes the secondary prefix from the top of secondaryPrefixes
 func (l *Logger) PopSecondaryPrefix() string {
 	if len(l.secondaryPrefixes) == 0 {
 		return ""

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -81,7 +81,7 @@ func GetLogger(isDebug bool, prefix string) *Logger {
 	}
 }
 
-// GetSecondaryPrefix returns the first secondary prefix
+// GetSecondaryPrefix returns all the secondary prefixes
 func (l *Logger) GetSecondaryPrefixes() []string {
 	return l.secondaryPrefixes
 }
@@ -104,7 +104,6 @@ func (l *Logger) UpdateSecondaryPrefixes(prefixes []string) {
 func (l *Logger) UpdateLastSecondaryPrefix(newPrefix string) {
 	l.PopSecondaryPrefix()
 	l.PushSecondaryPrefix(newPrefix)
-	l.updateLoggerPrefix()
 }
 
 // ResetSecondaryPrefixes clears all secondary prefixes

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -109,7 +109,6 @@ func (l *Logger) UpdateLastSecondaryPrefix(newPrefix string) {
 
 // ResetSecondaryPrefixes clears all secondary prefixes
 func (l *Logger) ResetSecondaryPrefixes() {
-	// Backward compatibility: clear all secondary prefixes
 	l.secondaryPrefixes = []string{}
 	l.updateLoggerPrefix()
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -119,14 +119,14 @@ func (l *Logger) updateLoggerPrefix() {
 	}
 }
 
-// Push adds a new secondary prefix to the end of secondaryPrefixes slice
-func (l *Logger) Push(prefix string) {
+// PushSecondaryPrefix adds a new secondary prefix to the end of secondaryPrefixes slice
+func (l *Logger) PushSecondaryPrefix(prefix string) {
 	l.secondaryPrefixes = append(l.secondaryPrefixes, prefix)
 	l.updateLoggerPrefix()
 }
 
-// Pop removes the last secondary prefix from the secondaryPrefixes slice
-func (l *Logger) Pop() string {
+// PopSecondaryPrefix removes the last secondary prefix from the secondaryPrefixes slice
+func (l *Logger) PopSecondaryPrefix() string {
 	if len(l.secondaryPrefixes) == 0 {
 		return ""
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -86,6 +86,14 @@ func (l *Logger) GetSecondaryPrefixes() []string {
 	return l.secondaryPrefixes
 }
 
+// GetLastSecondaryPrefix returns the last secondary prefix
+func (l *Logger) GetLastSecondaryPrefix() string {
+	if len(l.secondaryPrefixes) == 0 {
+		return ""
+	}
+	return l.secondaryPrefixes[len(l.secondaryPrefixes)-1]
+}
+
 // UpdateSecondaryPrefixes replaces all secondary prefixes with the new one
 func (l *Logger) UpdateSecondaryPrefixes(prefixes []string) {
 	l.secondaryPrefixes = prefixes

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -136,6 +136,14 @@ func (l *Logger) PopSecondaryPrefix() string {
 	return lastPrefix
 }
 
+// WithAddtionalSecondaryPrefix is helpful you want to run
+// one or more logging statements using an additional secondary prefix
+func (l *Logger) WithAdditionalSecondaryPrefix(prefix string, fn func()) {
+	l.PushSecondaryPrefix(prefix)
+	defer l.PopSecondaryPrefix()
+	fn()
+}
+
 // GetQuietLogger Returns a logger that only emits critical logs. Useful for anti-cheat stages.
 func GetQuietLogger(prefix string) *Logger {
 	color.NoColor = false


### PR DESCRIPTION
- Preserve backward compatibility
- Add Push() and Pop() methods

- Introduced WithAdditionalSecondaryPrefix() because I found myself using the following pattern

```
logger.PushSecondaryPrefix(...)
logger.[Info|Debug|Success]()
logger.PopSecondaryPrefix()
```