### PR TITLE
Add `random.Float64()` support

### DIFF
--- a/random/helpers.go
+++ b/random/helpers.go
@@ -68,6 +68,20 @@ func RandomInts(min, max int, count int) []int {
 	return randomInts
 }
 
+// RandomFloat64 returns a random float64 number between [min, max)
+func RandomFloat64(min, max float64) float64 {
+	return min + rng.Float64()*(max-min)
+}
+
+// RandomFloat64s returns an array of `count` random Float64 values between [min, max).
+func RandomFloat64s(min, max float64, count int) []float64 {
+	randomFloats := make([]float64, count)
+	for i := range count {
+		randomFloats[i] = RandomFloat64(min, max)
+	}
+	return randomFloats
+}
+
 // RandomWord returns a random word from the list of words.
 func RandomWord() string {
 	return randomWords[rng.Intn(len(randomWords))]

--- a/random/helpers.go
+++ b/random/helpers.go
@@ -70,6 +70,9 @@ func RandomInts(min, max int, count int) []int {
 
 // RandomFloat64 returns a random float64 number between [min, max)
 func RandomFloat64(min, max float64) float64 {
+	if max < min {
+		panic("max boundary is less than or equal to min boundary")
+	}
 	return min + rng.Float64()*(max-min)
 }
 

--- a/random/helpers.go
+++ b/random/helpers.go
@@ -71,7 +71,7 @@ func RandomInts(min, max int, count int) []int {
 // RandomFloat64 returns a random float64 number between [min, max)
 func RandomFloat64(min, max float64) float64 {
 	if max < min {
-		panic("max boundary is less than or equal to min boundary")
+		panic("max boundary is less than min boundary")
 	}
 	return min + rng.Float64()*(max-min)
 }

--- a/random/helpers_test.go
+++ b/random/helpers_test.go
@@ -115,6 +115,12 @@ func TestRandomFloat64(t *testing.T) {
 		}
 	})
 
+	t.Run("panics if max is smaller than min", func(t *testing.T) {
+		assert.PanicsWithValue(t, "max boundary is less than or equal to min boundary", func() {
+			RandomFloat64(1.0, 0.0)
+		})
+	})
+
 	t.Run("mean is within ±0.01 of expected in ≥95 of 100 runs (10k samples each)", func(t *testing.T) {
 		min, max := 0.0, 1.0
 		runs := 100

--- a/random/helpers_test.go
+++ b/random/helpers_test.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -99,6 +100,51 @@ func TestRandomUniqueInts(t *testing.T) {
 			assert.False(t, seen[val], "values should be unique")
 			seen[val] = true
 		}
+	})
+}
+
+func TestRandomFloat64(t *testing.T) {
+	Init()
+
+	t.Run("values are within range [min, max)", func(t *testing.T) {
+		min, max := 0.0, 1.0
+		for range 1000 {
+			val := RandomFloat64(min, max)
+			assert.GreaterOrEqual(t, val, min, "value should be greater than or equal to min boundary")
+			assert.Less(t, val, max, "value should be less than max boundary")
+		}
+	})
+
+	t.Run("mean is within ±0.01 of expected in ≥95 of 100 runs (10k samples each)", func(t *testing.T) {
+		min, max := 0.0, 1.0
+		runs := 100
+		samples := 10000
+		tolerance := 0.01
+		expectedMean := (min + max) / 2
+		meansWithinTolerance := 0
+
+		for range runs {
+			var total float64
+			for range samples {
+				total += RandomFloat64(min, max)
+			}
+			mean := total / float64(samples)
+			if math.Abs(mean-expectedMean) <= tolerance {
+				meansWithinTolerance++
+			}
+		}
+
+		assert.GreaterOrEqual(t, meansWithinTolerance, 95, "mean should be within ±0.01 of expected in ≥95 of 100 runs (10k samples each)")
+	})
+}
+
+func TestRandomFloat64s(t *testing.T) {
+	Init()
+
+	t.Run("returns specified number of random Float64s", func(t *testing.T) {
+		count := 100
+		result := RandomFloat64s(0, 1.0, count)
+		assert.Equal(t, len(result), count, "slice length should be equal to count")
 	})
 }
 
@@ -249,6 +295,15 @@ func TestSeededRandomInt(t *testing.T) {
 
 	assert.Equal(t, RandomInt(1, 10), 9)
 	assert.Equal(t, RandomInt(1, 100), 54)
+}
+
+func TestSeededRandomFloat64(t *testing.T) {
+	os.Setenv("CODECRAFTERS_RANDOM_SEED", "42")
+	defer os.Unsetenv("CODECRAFTERS_RANDOM_SEED")
+	Init()
+
+	assert.Equal(t, RandomFloat64(1, 100), 37.92980774361663)
+	assert.Equal(t, RandomFloat64(1, 100), 7.534049182558273)
 }
 
 func TestSeededRandomString(t *testing.T) {

--- a/random/helpers_test.go
+++ b/random/helpers_test.go
@@ -116,7 +116,7 @@ func TestRandomFloat64(t *testing.T) {
 	})
 
 	t.Run("panics if max is smaller than min", func(t *testing.T) {
-		assert.PanicsWithValue(t, "max boundary is less than or equal to min boundary", func() {
+		assert.PanicsWithValue(t, "max boundary is less than min boundary", func() {
 			RandomFloat64(1.0, 0.0)
 		})
 	})


### PR DESCRIPTION
- Add support for random.RandomFloat64(), random.RandomFloat64s()
- Added corresponding test cases
- **Required for Redis/Geospatial**