### PR TITLE
[regenerate-fixtures] Workaround for grep-tester when grep is protected 

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -56,6 +56,14 @@ jobs:
           git fetch origin ${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
 
+      - name: Workaround for grep-tester
+        if: github.event.inputs.tester_repo == 'grep-tester'
+        run: |
+          TEMP_GREP_DIR="${{ runner.temp }}/temp-grep-dir"
+          mkdir -p $TEMP_GREP_DIR
+          cp $(which grep) $TEMP_GREP_DIR
+          export PATH="$TEMP_GREP_DIR:$PATH"
+
       - name: Regenerate Fixtures
         run: CODECRAFTERS_RECORD_FIXTURES=true make test
 

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -56,15 +56,17 @@ jobs:
           git fetch origin ${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
 
-      - name: Workaround for grep-tester when grep is protected
+      - name: Regenerate Fixtures with grep workaround
         if: inputs.tester_repo == 'grep-tester'
         run: |
           TEMP_GREP_DIR="${{ runner.temp }}/temp-grep-dir"
           mkdir -p $TEMP_GREP_DIR
           cp $(which grep) $TEMP_GREP_DIR
           export PATH="$TEMP_GREP_DIR:$PATH"
+          CODECRAFTERS_RECORD_FIXTURES=true make test
 
-      - name: Regenerate Fixtures
+      - name: Regenerate Fixtures (default)
+        if: inputs.tester_repo != 'grep-tester'
         run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -56,7 +56,7 @@ jobs:
           git fetch origin ${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
 
-      - name: Workaround for grep-tester
+      - name: Workaround for grep-tester when grep is protected
         if: inputs.tester_repo == 'grep-tester'
         run: |
           TEMP_GREP_DIR="${{ runner.temp }}/temp-grep-dir"

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -57,7 +57,7 @@ jobs:
           git checkout ${{ github.head_ref }}
 
       - name: Workaround for grep-tester
-        if: github.event.inputs.tester_repo == 'grep-tester'
+        if: inputs.tester_repo == 'grep-tester'
         run: |
           TEMP_GREP_DIR="${{ runner.temp }}/temp-grep-dir"
           mkdir -p $TEMP_GREP_DIR


### PR DESCRIPTION
**Issue:**

Tagging `regenerate-fixtures` is [currently broken on grep-tester ](https://github.com/codecrafters-io/grep-tester/actions/runs/16961855005/job/48076338769)

<img width="1388" height="818" alt="image" src="https://github.com/user-attachments/assets/9b725f93-bfa9-4070-8955-ef1b28b8d51d" />

**Cause:**

When grep is in a protected folder, `mv grep somewhere-else` does not work.

**Workaround:**

Copying grep to a non-protected temp folder first, so that moving it again won't cause errors.

**Confirmed that the workaround works:**

https://github.com/codecrafters-io/grep-tester/actions/runs/16962886930
