### PR TITLE
Make `ResolveAbsolutePath` public

### DIFF
--- a/executable/executable.go
+++ b/executable/executable.go
@@ -139,7 +139,7 @@ func (e *Executable) Start(args ...string) error {
 	}
 
 	// Get the absolute path for e.Path
-	absolutePath, err := resolveAbsolutePath(e.Path)
+	absolutePath, err := ResolveAbsolutePath(e.Path)
 
 	if err != nil {
 		return fmt.Errorf("%s not found", filepath.Base(e.Path))

--- a/executable/utils.go
+++ b/executable/utils.go
@@ -84,7 +84,7 @@ func closeAllWithCloserFunc(closer func(io.Closer) error, streams ...io.Closer) 
 // 1. If executable is not found ('path' is neither in $PATH, nor found at the path specified) -> Error is returned
 // 2. If the 'path' contains slash, its absolute path is returned
 // 3. If the 'path' does not contains a slash, it is searched for in PATH and its absolute path
-func resolveAbsolutePath(path string) (absolutePath string, err error) {
+func ResolveAbsolutePath(path string) (absolutePath string, err error) {
 	executablePath, err := exec.LookPath(path)
 
 	// exec.LeookPath() failed: Try filepath.Abs()

--- a/executable/utils.go
+++ b/executable/utils.go
@@ -87,7 +87,7 @@ func closeAllWithCloserFunc(closer func(io.Closer) error, streams ...io.Closer) 
 func ResolveAbsolutePath(path string) (absolutePath string, err error) {
 	executablePath, err := exec.LookPath(path)
 
-	// exec.LeookPath() failed: Try filepath.Abs()
+	// exec.LookPath() failed: Try filepath.Abs()
 	if err != nil {
 		return filepath.Abs(path)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a visibility/name change to a path-resolution helper plus a call-site update, with no behavioral changes expected beyond external packages now being able to use it.
> 
> **Overview**
> Makes the executable path resolver public by renaming `resolveAbsolutePath` to `ResolveAbsolutePath` and updating `Executable.Start` to call the exported function.
> 
> Also fixes a small typo in a comment (`exec.LookPath`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a85eb574d5a59e08007d87c7cf31b1bf733842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->